### PR TITLE
Update setup_icacl.sh

### DIFF
--- a/setup_icacl.sh
+++ b/setup_icacl.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-rm -rf /opt/Citrix/ICAClient/keystore/cacerts
-ln -s /etc/ssl/certs/ cacerts
+mv /opt/Citrix/ICAClient/keystore/cacerts /opt/Citrix/ICAClient/keystore/cacerts.bakup
+ln -s /etc/ssl/certs/ /opt/Citrix/ICAClient/keystore/cacerts


### PR DESCRIPTION
Hi there. Sorry for the unsolicited pull request, but I just thought a couple tweaks for safety might help someone. This is still very Debian based, but doesn't assume you're running the script in the `/opt/Citrix/ICAClient/keystore` directory. Also, instead of delete the old certs, it just moves them.